### PR TITLE
Add Context Menu and Keyboard Shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-accordion": "^1.2.1",
         "@radix-ui/react-alert-dialog": "^1.1.2",
+        "@radix-ui/react-context-menu": "^2.2.4",
         "@radix-ui/react-dialog": "^1.1.2",
         "@radix-ui/react-dropdown-menu": "^2.1.2",
         "@radix-ui/react-label": "^2.1.0",
@@ -801,6 +802,358 @@
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.4.tgz",
+      "integrity": "sha512-ap4wdGwK52rJxGkwukU1NrnEodsUFQIooANKu+ey7d6raQ2biTcEf8za1zr0mgFHieevRTB2nK4dJeN8pTAZGQ==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-menu": "2.1.4",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.1.tgz",
+      "integrity": "sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA=="
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.1.tgz",
+      "integrity": "sha512-NaVpZfmv8SKeZbn4ijN2V3jlHA9ngBG16VnIIm22nUR0Yk8KUALyBxT3KYEUnNuch9sTE8UTsS3whzBgKOL30w==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.1.tgz",
+      "integrity": "sha512-LwT3pSho9Dljg+wY2KN2mrrh6y3qELfftINERIzBUO9e0N+t0oMTyn3k9iv+ZqgrwGkRnLpNJrsMv9BZlt2yuA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz",
+      "integrity": "sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.3.tgz",
+      "integrity": "sha512-onrWn/72lQoEucDmJnr8uczSNTujT0vJnA/X5+3AkChVPowr8n1yvIKIabhWyMQeMvvmdpsvcyDqx3X1LEXCPg==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.1.tgz",
+      "integrity": "sha512-01omzJAYRxXdG2/he/+xy+c8a8gCydoQ1yOxnWNcRhrrBW5W+RQJ22EK1SaO8tb3WoUsuEw7mJjBozPzihDFjA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-menu": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.4.tgz",
+      "integrity": "sha512-BnOgVoL6YYdHAG6DtXONaR29Eq4nvbi8rutrV/xlr3RQCMMb3yqP85Qiw/3NReozrSW+4dfLkK+rc1hb4wPU/A==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-dismissable-layer": "1.1.3",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-popper": "1.2.1",
+        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-roving-focus": "1.1.1",
+        "@radix-ui/react-slot": "1.1.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "aria-hidden": "^1.1.1",
+        "react-remove-scroll": "^2.6.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.1.tgz",
+      "integrity": "sha512-3kn5Me69L+jv82EKRuQCXdYyf1DqHwD2U/sxoNgBGCB7K9TRc3bQamQ+5EPM9EvyPdli0W41sROd+ZU1dTCztw==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.3.tgz",
+      "integrity": "sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.2.tgz",
+      "integrity": "sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz",
+      "integrity": "sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.1.tgz",
+      "integrity": "sha512-QE1RoxPGJ/Nm8Qmk0PxP8ojmoaS67i0s7hVssS7KuI2FQoc/uzVlZsqKfQvxPE6D8hICCPHJ4D88zNhT3OOmkw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-collection": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-direction": "1.1.0",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-controllable-state": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.1.tgz",
+      "integrity": "sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context-menu/node_modules/react-remove-scroll": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.6.2.tgz",
+      "integrity": "sha512-KmONPx5fnlXYJQqC62Q+lwIeAk64ws/cUw6omIumRzMRPqgnYqhSSti99nbj0Ry13bv7dF+BKn7NB+OqkdZGTw==",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.1",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4428,15 +4781,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.0.0"
-      }
-    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -5903,20 +6247,19 @@
       }
     },
     "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.6.tgz",
-      "integrity": "sha512-DtSYaao4mBmX+HDo5YWYdBWQwYIQQshUV/dVxFxK+KM26Wjwp1gZ6rv6OC3oujI6Bfu6Xyg3TwK533AQutsn/g==",
-      "license": "MIT",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
       "dependencies": {
-        "react-style-singleton": "^2.2.1",
+        "react-style-singleton": "^2.2.2",
         "tslib": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -5925,21 +6268,19 @@
       }
     },
     "node_modules/react-style-singleton": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
-      "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
-      "license": "MIT",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
       "dependencies": {
         "get-nonce": "^1.0.0",
-        "invariant": "^2.2.4",
         "tslib": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -6904,10 +7245,9 @@
       }
     },
     "node_modules/use-callback-ref": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.2.tgz",
-      "integrity": "sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==",
-      "license": "MIT",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -6915,8 +7255,8 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.2",
+    "@radix-ui/react-context-menu": "^2.2.4",
     "@radix-ui/react-dialog": "^1.1.2",
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-label": "^2.1.0",

--- a/src/components/flow-builder/components/context-menu/flow-context-menu.tsx
+++ b/src/components/flow-builder/components/context-menu/flow-context-menu.tsx
@@ -1,0 +1,285 @@
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
+import { AVAILABLE_NODES } from "../blocks";
+import { useInsertNode } from "@/hooks/use-insert-node";
+import { useCallback, useEffect, useState } from "react";
+import { BuilderNode, BuilderNodeType } from "../blocks/types";
+import { Icon } from "@iconify/react";
+import { useReactFlow, useViewport, Node } from "@xyflow/react";
+import { useFlowStore } from "@/stores/flow-store";
+import { useShallow } from "zustand/shallow";
+import { toast } from "sonner";
+
+interface FlowContextMenuProps {
+  children: React.ReactNode;
+}
+
+export function FlowContextMenu({ children }: FlowContextMenuProps) {
+  const insertNode = useInsertNode();
+  const { getNodes, getEdges, setNodes, setEdges } = useReactFlow();
+  const viewport = useViewport();
+  const [deleteNode, deleteEdge, showNodeProperties] = useFlowStore(
+    useShallow((s) => [
+      s.actions.nodes.deleteNode, 
+      s.actions.edges.deleteEdge,
+      s.actions.sidebar.showNodePropertiesOf
+    ])
+  );
+  const [copiedNode, setCopiedNode] = useState<Node | null>(null);
+  const [contextMenuType, setContextMenuType] = useState<'canvas' | 'node'>('canvas');
+  const [selectedNode, setSelectedNode] = useState<Node | null>(null);
+  const [menuKey, setMenuKey] = useState(0);
+
+  const handleAddNode = useCallback(
+    (type: BuilderNodeType, event: { clientX: number; clientY: number }) => {
+      const rect = document.querySelector('.react-flow')?.getBoundingClientRect();
+      if (rect) {
+        const position = {
+          x: (event.clientX - rect.left - viewport.x - 150) / viewport.zoom,
+          y: (event.clientY - rect.top - viewport.y) / viewport.zoom,
+        };
+        insertNode(type, position);
+      }
+    },
+    [insertNode, viewport]
+  );
+
+  const getSelectedNodes = useCallback(() => {
+    return getNodes().filter(
+      (node) => 
+        node.selected && 
+        node.type !== BuilderNode.START && 
+        node.type !== BuilderNode.END
+    );
+  }, [getNodes]);
+
+  const handleDeleteSelected = useCallback(() => {
+    const selectedNodes = getSelectedNodes();
+    const selectedEdges = getEdges().filter((edge) => edge.selected);
+    
+    selectedNodes.forEach((node) => deleteNode(node));
+    selectedEdges.forEach((edge) => deleteEdge(edge));
+  }, [getEdges, deleteNode, deleteEdge, getSelectedNodes]);
+
+  const handleSelectAll = useCallback(() => {
+    setNodes((nodes) =>
+      nodes.map((node) => ({
+        ...node,
+        selected: node.type !== BuilderNode.START && node.type !== BuilderNode.END
+      }))
+    );
+    setEdges((edges) =>
+      edges.map((edge) => ({ ...edge, selected: true }))
+    );
+  }, [setNodes, setEdges]);
+
+  const handleCopyNode = useCallback(() => {
+    if (selectedNode) {
+      setCopiedNode(selectedNode);
+      toast.success("Node copied", {
+        description: "Press Ctrl+V to paste the node",
+        dismissible: true,
+      });
+    }
+  }, [selectedNode]);
+
+  const handlePasteNode = useCallback((event: { clientX: number; clientY: number }) => {
+    if (copiedNode) {
+      const rect = document.querySelector('.react-flow')?.getBoundingClientRect();
+      if (rect) {
+        const position = {
+          x: (event.clientX - rect.left - viewport.x) / viewport.zoom,
+          y: (event.clientY - rect.top - viewport.y) / viewport.zoom,
+        };
+        insertNode(copiedNode.type as BuilderNodeType, position);
+      }
+    }
+  }, [copiedNode, insertNode, viewport]);
+
+  const handleDuplicateNode = useCallback(() => {
+    if (selectedNode) {
+      const offset = 50;
+      const position = {
+        x: selectedNode.position.x + offset,
+        y: selectedNode.position.y + offset,
+      };
+      insertNode(selectedNode.type as BuilderNodeType, position);
+      toast.success("Node duplicated");
+    }
+  }, [selectedNode, insertNode]);
+
+  const handleContextMenu = useCallback((event: React.MouseEvent) => {
+    const target = event.target as HTMLElement;
+    const nodeElement = target.closest('.react-flow__node');
+    
+    if (nodeElement) {
+      const nodeId = nodeElement.getAttribute('data-id');
+      const node = getNodes().find(n => n.id === nodeId);
+      if (node?.type !== BuilderNode.START && node?.type !== BuilderNode.END) {
+        setContextMenuType('node');
+        setSelectedNode(node || null);
+      } else {
+        setContextMenuType('canvas');
+        setSelectedNode(null);
+      }
+    } else {
+      setContextMenuType('canvas');
+      setSelectedNode(null);
+      setMenuKey(prev => prev + 1);
+    }
+  }, [getNodes]);
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    if (!open) {
+      setSelectedNode(null);
+      setContextMenuType('canvas');
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Delete') {
+        handleDeleteSelected();
+      }
+      
+      if (event.key === 'a' && (event.ctrlKey || event.metaKey)) {
+        event.preventDefault();
+        if (getNodes().length > 2) {
+          handleSelectAll();
+        }
+      }
+
+      if (event.key === 'c' && (event.ctrlKey || event.metaKey) && selectedNode) {
+        event.preventDefault();
+        handleCopyNode();
+      }
+
+      if (event.key === 'd' && (event.ctrlKey || event.metaKey) && selectedNode) {
+        event.preventDefault();
+        handleDuplicateNode();
+      }
+
+      if (event.key === 'v' && (event.ctrlKey || event.metaKey) && copiedNode) {
+        event.preventDefault();
+        const rect = document.querySelector('.react-flow')?.getBoundingClientRect();
+        if (rect) {
+          const center = {
+            clientX: rect.left + rect.width / 2,
+            clientY: rect.top + rect.height / 2,
+          };
+          handlePasteNode(center);
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleDeleteSelected, handleSelectAll, handleCopyNode, handlePasteNode, handleDuplicateNode, selectedNode, copiedNode, getNodes]);
+
+  const selectedCount = getSelectedNodes().length;
+  const canSelectAll = getNodes().length > 2;
+
+  return (
+    <ContextMenu key={menuKey} onOpenChange={handleOpenChange}>
+      <ContextMenuTrigger asChild>
+        <div 
+          className="flex h-full w-full"
+          onContextMenu={handleContextMenu}
+        >
+          {children}
+        </div>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="w-64">
+        {contextMenuType === 'canvas' ? (
+          <>
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>
+                <Icon icon="mynaui:plus" className="mr-2 h-4 w-4" />
+                Add Node
+              </ContextMenuSubTrigger>
+              <ContextMenuSubContent className="w-48">
+                {AVAILABLE_NODES.map((node) => (
+                  <ContextMenuItem
+                    key={node.type}
+                    onSelect={(e: any) => {
+                      const event = e.target.ownerDocument.defaultView.event;
+                      handleAddNode(node.type as BuilderNodeType, { 
+                        clientX: event.clientX, 
+                        clientY: event.clientY 
+                      });
+                    }}
+                  >
+                    <Icon icon={node.icon} className="mr-2 h-4 w-4" />
+                    {node.title}
+                  </ContextMenuItem>
+                ))}
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+            <ContextMenuSeparator />
+            <ContextMenuItem 
+              onSelect={handleSelectAll}
+              disabled={!canSelectAll}
+            >
+              <Icon icon="mynaui:select-all" className="mr-2 h-4 w-4" />
+              Select All
+              <span className="ml-auto text-xs text-muted-foreground">Ctrl+A</span>
+            </ContextMenuItem>
+            {copiedNode && (
+              <ContextMenuItem
+                onSelect={(e: any) => {
+                  const event = e.target.ownerDocument.defaultView.event;
+                  handlePasteNode({ 
+                    clientX: event.clientX, 
+                    clientY: event.clientY 
+                  });
+                }}
+              >
+                <Icon icon="mynaui:paste" className="mr-2 h-4 w-4" />
+                Paste Node
+                <span className="ml-auto text-xs text-muted-foreground">Ctrl+V</span>
+              </ContextMenuItem>
+            )}
+          </>
+        ) : (
+          <>
+            <ContextMenuItem onSelect={() => selectedNode && showNodeProperties({ id: selectedNode.id, type: selectedNode.type as BuilderNodeType })}>
+              <Icon icon="mynaui:settings" className="mr-2 h-4 w-4" />
+              Open Settings
+              <span className="ml-auto inline-flex items-center gap-2 text-xs text-muted-foreground">
+                <Icon icon="mynaui:settings" className="h-3 w-3" />
+                Alt+O
+              </span>
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem onSelect={handleCopyNode}>
+              <Icon icon="mynaui:copy" className="mr-2 h-4 w-4" />
+              Copy Node
+              <span className="ml-auto text-xs text-muted-foreground">Ctrl+C</span>
+            </ContextMenuItem>
+            <ContextMenuItem onSelect={handleDuplicateNode}>
+              <Icon icon="ph:copy-simple-duotone" className="mr-2 h-4 w-4" />
+              Duplicate Node
+              <span className="ml-auto text-xs text-muted-foreground">Ctrl+D</span>
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+            <ContextMenuItem onSelect={handleDeleteSelected} className="text-red-600">
+              <Icon icon="mynaui:trash" className="mr-2 h-4 w-4" />
+              Delete {selectedCount > 1 ? `${selectedCount} Nodes` : 'Node'}
+              <span className="ml-auto text-xs text-muted-foreground">Del</span>
+            </ContextMenuItem>
+          </>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
+  );
+} 

--- a/src/components/flow-builder/components/context-menu/flow-context-menu.tsx
+++ b/src/components/flow-builder/components/context-menu/flow-context-menu.tsx
@@ -31,7 +31,7 @@ export function FlowContextMenu({ children }: FlowContextMenuProps) {
   );
   
   const [copiedNode, setCopiedNode] = useState<Node | null>(null);
-  const [contextMenuType, setContextMenuType] = useState<'canvas' | 'node'>('canvas');
+  const [contextMenuType, setContextMenuType] = useState<'canvas' | 'node' | 'end-node'>('canvas');
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
   const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -65,7 +65,9 @@ export function FlowContextMenu({ children }: FlowContextMenuProps) {
   }, [getNodes]);
 
   const handleDeleteSelected = useCallback(() => {
-    if (contextMenuType === 'node' && selectedNode) {
+    if (contextMenuType === 'end-node' && selectedNode) {
+      deleteNode(selectedNode);
+    } else if (contextMenuType === 'node' && selectedNode) {
       deleteNode(selectedNode);
     } else {
       const selectedNodes = getSelectedNodes();
@@ -172,7 +174,10 @@ export function FlowContextMenu({ children }: FlowContextMenuProps) {
     if (nodeElement) {
       const nodeId = nodeElement.getAttribute('data-id');
       const node = getNodes().find(n => n.id === nodeId);
-      if (node?.type !== BuilderNode.START && node?.type !== BuilderNode.END) {
+      if (node?.type === BuilderNode.END) {
+        setContextMenuType('end-node');
+        setSelectedNode(node);
+      } else if (node?.type !== BuilderNode.START) {
         setNodes((nodes) =>
           nodes.map((n) => ({
             ...n,
@@ -387,6 +392,20 @@ export function FlowContextMenu({ children }: FlowContextMenuProps) {
                   </button>
                 </>
               )}
+            </div>
+          ) : contextMenuType === 'end-node' ? (
+            <div className="space-y-1">
+              <button
+                className={cn(
+                  "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none text-red-600",
+                  "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+                )}
+                onClick={handleDeleteSelected}
+              >
+                <Icon icon="mynaui:trash" className="mr-2 h-4 w-4" />
+                Delete End Node
+                <span className="ml-auto text-xs text-muted-foreground">Del</span>
+              </button>
             </div>
           ) : (
             <div className="space-y-1">

--- a/src/components/flow-builder/components/context-menu/flow-context-menu.tsx
+++ b/src/components/flow-builder/components/context-menu/flow-context-menu.tsx
@@ -1,25 +1,21 @@
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuSeparator,
-  ContextMenuSub,
-  ContextMenuSubContent,
-  ContextMenuSubTrigger,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu";
 import { AVAILABLE_NODES } from "../blocks";
 import { useInsertNode } from "@/hooks/use-insert-node";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { BuilderNode, BuilderNodeType } from "../blocks/types";
 import { Icon } from "@iconify/react";
 import { useReactFlow, useViewport, Node } from "@xyflow/react";
 import { useFlowStore } from "@/stores/flow-store";
 import { useShallow } from "zustand/shallow";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 
 interface FlowContextMenuProps {
   children: React.ReactNode;
+}
+
+interface MenuPosition {
+  x: number;
+  y: number;
 }
 
 export function FlowContextMenu({ children }: FlowContextMenuProps) {
@@ -33,23 +29,30 @@ export function FlowContextMenu({ children }: FlowContextMenuProps) {
       s.actions.sidebar.showNodePropertiesOf
     ])
   );
+  
   const [copiedNode, setCopiedNode] = useState<Node | null>(null);
   const [contextMenuType, setContextMenuType] = useState<'canvas' | 'node'>('canvas');
   const [selectedNode, setSelectedNode] = useState<Node | null>(null);
-  const [menuKey, setMenuKey] = useState(0);
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [showNodeSubmenu, setShowNodeSubmenu] = useState(false);
+  const closeTimeoutRef = useRef<NodeJS.Timeout>();
 
   const handleAddNode = useCallback(
-    (type: BuilderNodeType, event: { clientX: number; clientY: number }) => {
+    (type: BuilderNodeType) => {
+      if (!menuPosition) return;
+      
       const rect = document.querySelector('.react-flow')?.getBoundingClientRect();
       if (rect) {
         const position = {
-          x: (event.clientX - rect.left - viewport.x - 150) / viewport.zoom,
-          y: (event.clientY - rect.top - viewport.y) / viewport.zoom,
+          x: (menuPosition.x - rect.left - viewport.x - 150) / viewport.zoom,
+          y: (menuPosition.y - rect.top - viewport.y) / viewport.zoom,
         };
         insertNode(type, position);
+        setIsMenuOpen(false);
       }
     },
-    [insertNode, viewport]
+    [insertNode, viewport, menuPosition]
   );
 
   const getSelectedNodes = useCallback(() => {
@@ -62,12 +65,16 @@ export function FlowContextMenu({ children }: FlowContextMenuProps) {
   }, [getNodes]);
 
   const handleDeleteSelected = useCallback(() => {
-    const selectedNodes = getSelectedNodes();
-    const selectedEdges = getEdges().filter((edge) => edge.selected);
-    
-    selectedNodes.forEach((node) => deleteNode(node));
-    selectedEdges.forEach((edge) => deleteEdge(edge));
-  }, [getEdges, deleteNode, deleteEdge, getSelectedNodes]);
+    if (contextMenuType === 'node' && selectedNode) {
+      deleteNode(selectedNode);
+    } else {
+      const selectedNodes = getSelectedNodes();
+      const selectedEdges = getEdges().filter((edge) => edge.selected);
+      selectedNodes.forEach((node) => deleteNode(node));
+      selectedEdges.forEach((edge) => deleteEdge(edge));
+    }
+    setIsMenuOpen(false);
+  }, [getEdges, deleteNode, deleteEdge, getSelectedNodes, contextMenuType, selectedNode]);
 
   const handleSelectAll = useCallback(() => {
     setNodes((nodes) =>
@@ -79,6 +86,7 @@ export function FlowContextMenu({ children }: FlowContextMenuProps) {
     setEdges((edges) =>
       edges.map((edge) => ({ ...edge, selected: true }))
     );
+    setIsMenuOpen(false);
   }, [setNodes, setEdges]);
 
   const handleCopyNode = useCallback(() => {
@@ -88,35 +96,76 @@ export function FlowContextMenu({ children }: FlowContextMenuProps) {
         description: "Press Ctrl+V to paste the node",
         dismissible: true,
       });
+      setIsMenuOpen(false);
     }
   }, [selectedNode]);
 
-  const handlePasteNode = useCallback((event: { clientX: number; clientY: number }) => {
-    if (copiedNode) {
+  const handlePasteNode = useCallback(() => {
+    if (copiedNode && menuPosition) {
       const rect = document.querySelector('.react-flow')?.getBoundingClientRect();
       if (rect) {
         const position = {
-          x: (event.clientX - rect.left - viewport.x) / viewport.zoom,
-          y: (event.clientY - rect.top - viewport.y) / viewport.zoom,
+          x: (menuPosition.x - rect.left - viewport.x) / viewport.zoom,
+          y: (menuPosition.y - rect.top - viewport.y) / viewport.zoom,
         };
         insertNode(copiedNode.type as BuilderNodeType, position);
+        setIsMenuOpen(false);
       }
     }
-  }, [copiedNode, insertNode, viewport]);
+  }, [copiedNode, insertNode, viewport, menuPosition]);
+
+  const findFreePosition = useCallback((baseNode: Node) => {
+    const nodes = getNodes();
+    const nodeSize = { width: 300, height: 150 }; // Approximate node size
+    const padding = 20; // Space between nodes
+    const positions = [
+      { x: 1, y: 0 },  // right
+      { x: 0, y: 1 },  // bottom
+      { x: 1, y: 1 },  // bottom-right
+      { x: -1, y: 0 }, // left
+      { x: 0, y: -1 }, // top
+      { x: -1, y: -1 }, // top-left
+      { x: 1, y: -1 }, // top-right
+      { x: -1, y: 1 }, // bottom-left
+    ];
+
+    for (const pos of positions) {
+      const candidatePosition = {
+        x: baseNode.position.x + pos.x * (nodeSize.width + padding),
+        y: baseNode.position.y + pos.y * (nodeSize.height + padding)
+      };
+
+      // Check if this position overlaps with any existing node
+      const hasOverlap = nodes.some(node => {
+        if (node.id === baseNode.id) return false;
+        const dx = Math.abs(node.position.x - candidatePosition.x);
+        const dy = Math.abs(node.position.y - candidatePosition.y);
+        return dx < nodeSize.width && dy < nodeSize.height;
+      });
+
+      if (!hasOverlap) {
+        return candidatePosition;
+      }
+    }
+
+    // If all positions are taken, return a position with offset
+    return {
+      x: baseNode.position.x + (nodeSize.width + padding),
+      y: baseNode.position.y + (nodeSize.height + padding)
+    };
+  }, [getNodes]);
 
   const handleDuplicateNode = useCallback(() => {
     if (selectedNode) {
-      const offset = 50;
-      const position = {
-        x: selectedNode.position.x + offset,
-        y: selectedNode.position.y + offset,
-      };
-      insertNode(selectedNode.type as BuilderNodeType, position);
+      const newPosition = findFreePosition(selectedNode);
+      insertNode(selectedNode.type as BuilderNodeType, newPosition);
       toast.success("Node duplicated");
+      setIsMenuOpen(false);
     }
-  }, [selectedNode, insertNode]);
+  }, [selectedNode, insertNode, findFreePosition]);
 
   const handleContextMenu = useCallback((event: React.MouseEvent) => {
+    event.preventDefault();
     const target = event.target as HTMLElement;
     const nodeElement = target.closest('.react-flow__node');
     
@@ -124,6 +173,12 @@ export function FlowContextMenu({ children }: FlowContextMenuProps) {
       const nodeId = nodeElement.getAttribute('data-id');
       const node = getNodes().find(n => n.id === nodeId);
       if (node?.type !== BuilderNode.START && node?.type !== BuilderNode.END) {
+        setNodes((nodes) =>
+          nodes.map((n) => ({
+            ...n,
+            selected: n.id === nodeId
+          }))
+        );
         setContextMenuType('node');
         setSelectedNode(node || null);
       } else {
@@ -133,19 +188,29 @@ export function FlowContextMenu({ children }: FlowContextMenuProps) {
     } else {
       setContextMenuType('canvas');
       setSelectedNode(null);
-      setMenuKey(prev => prev + 1);
     }
-  }, [getNodes]);
 
-  const handleOpenChange = useCallback((open: boolean) => {
-    if (!open) {
-      setSelectedNode(null);
-      setContextMenuType('canvas');
-    }
-  }, []);
+    setMenuPosition({ x: event.clientX, y: event.clientY });
+    setIsMenuOpen(true);
+  }, [getNodes, setNodes]);
 
   useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      const isContextMenu = target.closest('.flow-context-menu');
+      const isNodeSubmenu = target.closest('.node-submenu');
+      
+      if (!isContextMenu && !isNodeSubmenu) {
+        setIsMenuOpen(false);
+        setShowNodeSubmenu(false);
+      }
+    };
+
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsMenuOpen(false);
+      }
+
       if (event.key === 'Delete') {
         handleDeleteSelected();
       }
@@ -169,117 +234,215 @@ export function FlowContextMenu({ children }: FlowContextMenuProps) {
 
       if (event.key === 'v' && (event.ctrlKey || event.metaKey) && copiedNode) {
         event.preventDefault();
-        const rect = document.querySelector('.react-flow')?.getBoundingClientRect();
-        if (rect) {
-          const center = {
-            clientX: rect.left + rect.width / 2,
-            clientY: rect.top + rect.height / 2,
-          };
-          handlePasteNode(center);
-        }
+        handlePasteNode();
       }
     };
 
+    document.addEventListener('click', handleClickOutside);
     document.addEventListener('keydown', handleKeyDown);
     return () => {
+      document.removeEventListener('click', handleClickOutside);
       document.removeEventListener('keydown', handleKeyDown);
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+      }
     };
   }, [handleDeleteSelected, handleSelectAll, handleCopyNode, handlePasteNode, handleDuplicateNode, selectedNode, copiedNode, getNodes]);
+
+  const handleAddNodeTriggerEnter = useCallback(() => {
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+    }
+    setShowNodeSubmenu(true);
+  }, []);
+
+  const handleAddNodeTriggerLeave = useCallback(() => {
+    closeTimeoutRef.current = setTimeout(() => {
+      setShowNodeSubmenu(false);
+    }, 100);
+  }, []);
+
+  const handleSubmenuEnter = useCallback(() => {
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+    }
+  }, []);
+
+  const handleSubmenuLeave = useCallback(() => {
+    setShowNodeSubmenu(false);
+  }, []);
 
   const selectedCount = getSelectedNodes().length;
   const canSelectAll = getNodes().length > 2;
 
+  const handleShowNodeProperties = useCallback(() => {
+    if (selectedNode) {
+      showNodeProperties({ 
+        id: selectedNode.id, 
+        type: selectedNode.type as BuilderNodeType 
+      });
+      setIsMenuOpen(false);
+    }
+  }, [selectedNode, showNodeProperties]);
+
   return (
-    <ContextMenu key={menuKey} onOpenChange={handleOpenChange}>
-      <ContextMenuTrigger asChild>
+    <>
+      <div 
+        className="flex h-full w-full"
+        onContextMenu={handleContextMenu}
+      >
+        {children}
+      </div>
+      {isMenuOpen && menuPosition && (
         <div 
-          className="flex h-full w-full"
-          onContextMenu={handleContextMenu}
+          className={cn(
+            "flow-context-menu fixed z-50 min-w-[220px] rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-none",
+            "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95"
+          )}
+          style={{
+            left: menuPosition.x,
+            top: menuPosition.y,
+          }}
         >
-          {children}
-        </div>
-      </ContextMenuTrigger>
-      <ContextMenuContent className="w-64">
-        {contextMenuType === 'canvas' ? (
-          <>
-            <ContextMenuSub>
-              <ContextMenuSubTrigger>
-                <Icon icon="mynaui:plus" className="mr-2 h-4 w-4" />
-                Add Node
-              </ContextMenuSubTrigger>
-              <ContextMenuSubContent className="w-48">
-                {AVAILABLE_NODES.map((node) => (
-                  <ContextMenuItem
-                    key={node.type}
-                    onSelect={(e: any) => {
-                      const event = e.target.ownerDocument.defaultView.event;
-                      handleAddNode(node.type as BuilderNodeType, { 
-                        clientX: event.clientX, 
-                        clientY: event.clientY 
-                      });
-                    }}
+          {contextMenuType === 'canvas' ? (
+            <div className="space-y-1">
+              <div className="relative">
+                <button
+                  className={cn(
+                    "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
+                    "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+                  )}
+                  onMouseEnter={handleAddNodeTriggerEnter}
+                  onMouseLeave={handleAddNodeTriggerLeave}
+                >
+                  <Icon icon="mynaui:plus" className="mr-2 h-4 w-4" />
+                  Add Node
+                  <Icon icon="lucide:chevron-right" className="ml-auto h-4 w-4" />
+                </button>
+                {showNodeSubmenu && (
+                  <div 
+                    className={cn(
+                      "node-submenu absolute left-full top-0 ml-0.5 min-w-[180px] rounded-md border bg-popover p-1",
+                      "animate-in fade-in-0 zoom-in-95"
+                    )}
+                    onMouseEnter={handleSubmenuEnter}
+                    onMouseLeave={handleSubmenuLeave}
                   >
-                    <Icon icon={node.icon} className="mr-2 h-4 w-4" />
-                    {node.title}
-                  </ContextMenuItem>
-                ))}
-              </ContextMenuSubContent>
-            </ContextMenuSub>
-            <ContextMenuSeparator />
-            <ContextMenuItem 
-              onSelect={handleSelectAll}
-              disabled={!canSelectAll}
-            >
-              <Icon icon="mynaui:select-all" className="mr-2 h-4 w-4" />
-              Select All
-              <span className="ml-auto text-xs text-muted-foreground">Ctrl+A</span>
-            </ContextMenuItem>
-            {copiedNode && (
-              <ContextMenuItem
-                onSelect={(e: any) => {
-                  const event = e.target.ownerDocument.defaultView.event;
-                  handlePasteNode({ 
-                    clientX: event.clientX, 
-                    clientY: event.clientY 
-                  });
-                }}
+                    {AVAILABLE_NODES.map((node) => (
+                      <button
+                        key={node.type}
+                        className={cn(
+                          "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
+                          "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+                        )}
+                        onClick={() => handleAddNode(node.type as BuilderNodeType)}
+                      >
+                        <Icon icon={node.icon} className="mr-2 h-4 w-4" />
+                        {node.title}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+              <div className="h-px my-1 bg-border" />
+              <button
+                className={cn(
+                  "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
+                  "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground",
+                  !canSelectAll && "opacity-50 cursor-not-allowed"
+                )}
+                onClick={handleSelectAll}
+                disabled={!canSelectAll}
               >
-                <Icon icon="mynaui:paste" className="mr-2 h-4 w-4" />
-                Paste Node
-                <span className="ml-auto text-xs text-muted-foreground">Ctrl+V</span>
-              </ContextMenuItem>
-            )}
-          </>
-        ) : (
-          <>
-            <ContextMenuItem onSelect={() => selectedNode && showNodeProperties({ id: selectedNode.id, type: selectedNode.type as BuilderNodeType })}>
-              <Icon icon="mynaui:settings" className="mr-2 h-4 w-4" />
-              Open Settings
-              <span className="ml-auto inline-flex items-center gap-2 text-xs text-muted-foreground">
-                <Icon icon="mynaui:settings" className="h-3 w-3" />
-                Alt+O
-              </span>
-            </ContextMenuItem>
-            <ContextMenuSeparator />
-            <ContextMenuItem onSelect={handleCopyNode}>
-              <Icon icon="mynaui:copy" className="mr-2 h-4 w-4" />
-              Copy Node
-              <span className="ml-auto text-xs text-muted-foreground">Ctrl+C</span>
-            </ContextMenuItem>
-            <ContextMenuItem onSelect={handleDuplicateNode}>
-              <Icon icon="ph:copy-simple-duotone" className="mr-2 h-4 w-4" />
-              Duplicate Node
-              <span className="ml-auto text-xs text-muted-foreground">Ctrl+D</span>
-            </ContextMenuItem>
-            <ContextMenuSeparator />
-            <ContextMenuItem onSelect={handleDeleteSelected} className="text-red-600">
-              <Icon icon="mynaui:trash" className="mr-2 h-4 w-4" />
-              Delete {selectedCount > 1 ? `${selectedCount} Nodes` : 'Node'}
-              <span className="ml-auto text-xs text-muted-foreground">Del</span>
-            </ContextMenuItem>
-          </>
-        )}
-      </ContextMenuContent>
-    </ContextMenu>
+                <Icon icon="mynaui:select-all" className="mr-2 h-4 w-4" />
+                Select All
+                <span className="ml-auto text-xs text-muted-foreground">Ctrl+A</span>
+              </button>
+              {copiedNode && (
+                <button
+                  className={cn(
+                    "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
+                    "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+                  )}
+                  onClick={handlePasteNode}
+                >
+                  <Icon icon="mynaui:paste" className="mr-2 h-4 w-4" />
+                  Paste Node
+                  <span className="ml-auto text-xs text-muted-foreground">Ctrl+V</span>
+                </button>
+              )}
+              {selectedCount > 0 && (
+                <>
+                  <div className="h-px my-1 bg-border" />
+                  <button
+                    className={cn(
+                      "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none text-red-600",
+                      "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+                    )}
+                    onClick={handleDeleteSelected}
+                  >
+                    <Icon icon="mynaui:trash" className="mr-2 h-4 w-4" />
+                    Delete {selectedCount} {selectedCount === 1 ? 'Node' : 'Nodes'}
+                    <span className="ml-auto text-xs text-muted-foreground">Del</span>
+                  </button>
+                </>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-1">
+              <button
+                className={cn(
+                  "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
+                  "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+                )}
+                onClick={handleShowNodeProperties}
+              >
+                <Icon icon="mynaui:settings" className="mr-2 h-4 w-4" />
+                Open Settings
+                <span className="ml-auto inline-flex items-center gap-2 text-xs text-muted-foreground">
+                  <Icon icon="mynaui:settings" className="h-3 w-3" />
+                  Alt+O
+                </span>
+              </button>
+              <div className="h-px my-1 bg-border" />
+              <button
+                className={cn(
+                  "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
+                  "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+                )}
+                onClick={handleCopyNode}
+              >
+                <Icon icon="mynaui:copy" className="mr-2 h-4 w-4" />
+                Copy Node
+                <span className="ml-auto text-xs text-muted-foreground">Ctrl+C</span>
+              </button>
+              <button
+                className={cn(
+                  "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none",
+                  "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+                )}
+                onClick={handleDuplicateNode}
+              >
+                <Icon icon="ph:copy-simple-duotone" className="mr-2 h-4 w-4" />
+                Duplicate Node
+                <span className="ml-auto text-xs text-muted-foreground">Ctrl+D</span>
+              </button>
+              <div className="h-px my-1 bg-border" />
+              <button
+                className={cn(
+                  "relative flex w-full cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none text-red-600",
+                  "hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+                )}
+                onClick={handleDeleteSelected}
+              >
+                <Icon icon="mynaui:trash" className="mr-2 h-4 w-4" />
+                Delete Node
+                <span className="ml-auto text-xs text-muted-foreground">Del</span>
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </>
   );
 } 

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -1,0 +1,208 @@
+"use client"
+
+import * as React from "react"
+import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
+import { Check, ChevronRight, Circle } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+interface ContextMenuProps extends React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Root> {
+  open?: boolean
+}
+
+const ContextMenu = ContextMenuPrimitive.Root
+
+const ContextMenuTrigger = ContextMenuPrimitive.Trigger
+
+const ContextMenuGroup = ContextMenuPrimitive.Group
+
+const ContextMenuPortal = ContextMenuPrimitive.Portal
+
+const ContextMenuSub = ContextMenuPrimitive.Sub
+
+const ContextMenuRadioGroup = ContextMenuPrimitive.RadioGroup
+
+const ContextMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubTrigger> & {
+    inset?: boolean
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <ContextMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=open]:bg-accent data-[state=open]:text-accent-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </ContextMenuPrimitive.SubTrigger>
+))
+ContextMenuSubTrigger.displayName = ContextMenuPrimitive.SubTrigger.displayName
+
+const ContextMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuSubContent.displayName = ContextMenuPrimitive.SubContent.displayName
+
+const ContextMenuContent = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Portal>
+    <ContextMenuPrimitive.Content
+      ref={ref}
+      alignOffset={-4}
+      className={cn(
+        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </ContextMenuPrimitive.Portal>
+))
+ContextMenuContent.displayName = ContextMenuPrimitive.Content.displayName
+
+const ContextMenuItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Item> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuItem.displayName = ContextMenuPrimitive.Item.displayName
+
+const ContextMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <ContextMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.CheckboxItem>
+))
+ContextMenuCheckboxItem.displayName =
+  ContextMenuPrimitive.CheckboxItem.displayName
+
+const ContextMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <ContextMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <ContextMenuPrimitive.ItemIndicator>
+        <Circle className="h-4 w-4 fill-current" />
+      </ContextMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </ContextMenuPrimitive.RadioItem>
+))
+ContextMenuRadioItem.displayName = ContextMenuPrimitive.RadioItem.displayName
+
+const ContextMenuLabel = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Label> & {
+    inset?: boolean
+  }
+>(({ className, inset, ...props }, ref) => (
+  <ContextMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      "px-2 py-1.5 text-sm font-semibold text-foreground",
+      inset && "pl-8",
+      className
+    )}
+    {...props}
+  />
+))
+ContextMenuLabel.displayName = ContextMenuPrimitive.Label.displayName
+
+const ContextMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof ContextMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof ContextMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <ContextMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-border", className)}
+    {...props}
+  />
+))
+ContextMenuSeparator.displayName = ContextMenuPrimitive.Separator.displayName
+
+const ContextMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+ContextMenuShortcut.displayName = "ContextMenuShortcut"
+
+export {
+  ContextMenu,
+  ContextMenuTrigger,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuCheckboxItem,
+  ContextMenuRadioItem,
+  ContextMenuLabel,
+  ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuGroup,
+  ContextMenuPortal,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuRadioGroup,
+}


### PR DESCRIPTION
# Add Context Menu and Keyboard Shortcuts
![image](https://github.com/user-attachments/assets/a2a2ddad-391b-4e75-bcf2-202eedb471a1)
![image](https://github.com/user-attachments/assets/b4c08f34-ce73-4b2b-91bf-05910216ad9e)

Video:
https://github.com/user-attachments/assets/8f40ddf9-3050-467e-85cf-c1d05699b7e3


Added right-click context menus and keyboard shortcuts to make the workflow builder more user-friendly.

## What's New
- Right-click on canvas to:
  - Add new nodes
  - Select all nodes
  - Paste copied nodes

- Right-click on nodes to:
  - Open settings
  - Copy/Duplicate nodes
  - Delete nodes

## Keyboard Shortcuts
- `Delete` - Delete selected node(s)
- `Ctrl/Cmd + A` - Select all nodes
- `Ctrl/Cmd + C` - Copy node
- `Ctrl/Cmd + V` - Paste node
- `Escape` - Close menu
